### PR TITLE
Add FAQ page and theme toggle

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,36 @@
+export default function FaqPage() {
+  const faqs = [
+    {
+      question: "Bietet ihr auch Wartung für bestehende Websites?",
+      answer:
+        "Ja, wir kümmern uns gerne um Pflege, Updates und Erweiterungen Ihrer bestehenden Seite – auch wenn sie nicht von uns erstellt wurde.",
+    },
+    {
+      question: "Wie läuft ein typisches Projekt ab?",
+      answer:
+        "Nach einem unverbindlichen Beratungsgespräch erstellen wir ein Angebot. Anschließend folgt die Umsetzung mit regelmäßigen Abstimmungen.",
+    },
+    {
+      question: "Kann ich individuelle Schulungen buchen?",
+      answer:
+        "Natürlich! Wir bieten Einzeltrainings und Workshops an, die genau auf Ihre Fragen zugeschnitten sind.",
+    },
+  ];
+
+  return (
+    <div className="container mx-auto px-4 py-20 max-w-3xl">
+      <h1 className="text-4xl font-bold mb-12 text-center">Häufige Fragen</h1>
+      <div className="space-y-6">
+        {faqs.map((faq) => (
+          <details
+            key={faq.question}
+            className="bg-white dark:bg-neutral-900 rounded-xl shadow p-6"
+          >
+            <summary className="cursor-pointer font-semibold">{faq.question}</summary>
+            <p className="mt-3 text-neutral-700 dark:text-neutral-300">{faq.answer}</p>
+          </details>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import config from "../config/site.config";
+import ThemeToggle from "./ThemeToggle";
 
 const links = [
   { href: config.links.home, label: "Home" },
@@ -9,6 +10,7 @@ const links = [
   { href: config.links.leistungen, label: "Leistungen" },
   { href: config.links.kurse, label: "Kurse" },
   { href: config.links.projekte, label: "Projekte" },
+  { href: config.links.faq, label: "FAQ" },
 ];
 
 export default function Header() {
@@ -18,7 +20,7 @@ export default function Header() {
         <Link href={config.links.home} className="text-xl font-bold tracking-tight hover:opacity-80">
           {config.company}
         </Link>
-        <nav className="flex gap-4">
+        <nav className="flex gap-4 items-center">
           {links.map(link => (
             <Link
               key={link.href}
@@ -28,6 +30,7 @@ export default function Header() {
               {link.label}
             </Link>
           ))}
+          <ThemeToggle />
         </nav>
       </div>
     </header>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initial = stored ? stored : prefersDark ? "dark" : "light";
+    setTheme(initial);
+    if (initial === "dark") {
+      document.documentElement.classList.add("dark");
+    }
+  }, []);
+
+  function toggle() {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    if (next === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    localStorage.setItem("theme", next);
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label="Theme wechseln"
+      className="p-2 rounded-md hover:bg-neutral-200 dark:hover:bg-neutral-800 transition"
+    >
+      {theme === "dark" ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </button>
+  );
+}

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -10,6 +10,7 @@ const config = {
     leistungen: "/leistungen",
     projekte: "/projekte",
     kurse: "/kurse",
+    faq: "/faq",
     impressum: "/impressum",
     datenschutz: "/datenschutz",
   },


### PR DESCRIPTION
## Summary
- add FAQ page with some common questions
- add link to FAQ in navigation
- include a theme toggle button using localStorage

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd5b604083328fa3d30f2191f934