### PR TITLE
Improve Next.js components

### DIFF
--- a/src/app/kurse/page.tsx
+++ b/src/app/kurse/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 import { User, Users, Smartphone, Shield } from "lucide-react";
 import { motion } from "framer-motion";
 
@@ -85,12 +86,12 @@ export default function KursePage() {
       </div>
       <div className="text-center mt-14">
         <p className="mb-3 text-lg">Sie möchten teilnehmen oder haben Fragen?</p>
-        <a
+        <Link
           href="/#kontakt"
           className="inline-block px-8 py-4 rounded-full bg-primary text-white font-semibold shadow hover:scale-105 transition"
         >
           Kontakt aufnehmen
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/src/app/projekte/page.tsx
+++ b/src/app/projekte/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 import { ExternalLink } from "lucide-react";
 import { motion } from "framer-motion";
 
@@ -49,11 +50,12 @@ export default function ProjektePage() {
             className="rounded-2xl shadow-lg bg-white dark:bg-neutral-900 overflow-hidden flex flex-col group hover:shadow-2xl transition"
           >
             <div className="h-56 bg-neutral-200 dark:bg-neutral-800 overflow-hidden relative">
-              <img
+              <Image
                 src={project.image}
                 alt={project.name}
+                fill
+                sizes="100vw"
                 className="object-cover w-full h-full group-hover:scale-105 transition"
-                loading="lazy"
               />
             </div>
             <div className="flex-1 flex flex-col p-7">

--- a/src/components/Kontaktformular.tsx
+++ b/src/components/Kontaktformular.tsx
@@ -3,7 +3,6 @@
 
 "use client";
 import { useState, useCallback, useEffect } from "react";
-import config from "../config/site.config";
 
 export default function Kontaktformular() {
   const [data, setData] = useState({ name: "", email: "", nachricht: "" });

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -1,4 +1,5 @@
 // src/components/TestimonialsSection.tsx
+import Image from "next/image";
 import config from "../config/site.config";
 
 export default function TestimonialsSection() {
@@ -9,9 +10,11 @@ export default function TestimonialsSection() {
         <div className="grid md:grid-cols-3 gap-8">
           {config.testimonials.map((testimonial, idx) => (
             <div key={idx} className="bg-neutral-100 dark:bg-neutral-800 rounded-2xl p-8 flex flex-col items-center shadow transition hover:scale-105">
-              <img
+              <Image
                 src={testimonial.image}
                 alt={testimonial.name}
+                width={80}
+                height={80}
                 className="w-20 h-20 rounded-full mb-4 object-cover border-4 border-primary shadow"
               />
               <blockquote className="italic text-lg text-center mb-4">“{testimonial.text}”</blockquote>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -8,7 +8,7 @@ export default function ThemeToggle() {
   useEffect(() => {
     const stored = localStorage.getItem("theme");
     const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const initial = stored ? stored : prefersDark ? "dark" : "light";
+    const initial = stored === "dark" || stored === "light" ? stored : prefersDark ? "dark" : "light";
     setTheme(initial);
     if (initial === "dark") {
       document.documentElement.classList.add("dark");


### PR DESCRIPTION
## Summary
- replace `<a>` with Next `<Link>` on the courses page
- use `next/image` for projects and testimonials
- clean up unused import in contact form
- handle theme initialization more strictly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841e2475d9483328474bf9b0d3ef801