### PR TITLE
Add responsive mobile sidebar

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,9 @@
 // src/components/Header.tsx
 
+"use client";
 import Link from "next/link";
+import { Menu, X } from "lucide-react";
+import { useState } from "react";
 import config from "../config/site.config";
 import ThemeToggle from "./ThemeToggle";
 
@@ -14,13 +17,15 @@ const links = [
 ];
 
 export default function Header() {
+  const [open, setOpen] = useState(false);
+
   return (
     <header className="sticky top-0 z-30 bg-white/80 dark:bg-neutral-900/80 shadow-md backdrop-blur">
       <div className="container mx-auto px-4 flex justify-between items-center h-16">
         <Link href={config.links.home} className="text-xl font-bold tracking-tight hover:opacity-80">
           {config.company}
         </Link>
-        <nav className="flex gap-4 items-center">
+        <nav className="hidden md:flex gap-4 items-center">
           {links.map(link => (
             <Link
               key={link.href}
@@ -32,7 +37,46 @@ export default function Header() {
           ))}
           <ThemeToggle />
         </nav>
+        <button
+          className="md:hidden p-2 rounded-md hover:bg-neutral-200 dark:hover:bg-neutral-800"
+          aria-label="Menü öffnen"
+          onClick={() => setOpen(true)}
+        >
+          <Menu className="w-6 h-6" />
+        </button>
       </div>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="absolute left-0 top-0 w-64 h-full bg-white dark:bg-neutral-900 p-4"
+            onClick={e => e.stopPropagation()}
+          >
+            <button
+              className="mb-4 p-2 rounded-md hover:bg-neutral-200 dark:hover:bg-neutral-800"
+              aria-label="Menü schließen"
+              onClick={() => setOpen(false)}
+            >
+              <X className="w-6 h-6" />
+            </button>
+            <nav className="flex flex-col gap-4">
+              {links.map(link => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="text-base font-medium hover:text-primary transition"
+                >
+                  {link.label}
+                </Link>
+              ))}
+              <ThemeToggle />
+            </nav>
+          </div>
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add `use client` directive and lucide icons imports
- implement mobile menu button and sidebar navigation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845c73c01ac833297e5abb71ed63c87